### PR TITLE
Adds support for automatically authenticating swagger-ui sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ swagger-ui.sublime-workspace
 .idea
 .project
 node_modules/*
+dist/basic_auth_info.json

--- a/dist/basic_auth_info.example.json
+++ b/dist/basic_auth_info.example.json
@@ -1,0 +1,5 @@
+{
+  "userId": "admin",
+  "password": "admin",
+  "comments": "Create your own basic_auth_info.json file to automatically authenticate your swagger-ui sessions"
+}

--- a/dist/index.html
+++ b/dist/index.html
@@ -43,6 +43,35 @@
         $('pre code').each(function(i, e) {
           hljs.highlightBlock(e)
         });
+        if (!window.authorizations.authz.key) {
+          $.getJSON('/swagger-ui/basic_auth_info.json').complete(function(response) {
+              if (response.statusText === 'OK') {
+                var login = JSON.parse(response.responseText);
+                delete login.comments;
+                $.ajax({
+                  type: "POST",
+                  url: '/login',
+                  data: JSON.stringify(login),
+                  contentType: "application/json;charset=utf-8",
+                  success: function(response) {
+                    if (response.status === 'Success') {
+                      window.authorizations.add(
+                        "key",
+                        new ApiKeyAuthorization(
+                          "Authorization",
+                          'Basic ' + btoa(response.token + ':'),
+                          "header"
+                        )
+                      );
+                    } else {
+                      log('Login credentials invalid');
+                    }
+                  },
+                  dataType: 'json'
+                });
+              }
+            });
+        }
       },
       onFailure: function(data) {
         log("Unable to Load SwaggerUI");


### PR DESCRIPTION
Summary:
Users will need to create basic_auth_info.json file with default login
info.
This assumes that the auth endpoint is /login, it doesn't try to derive
this information from the swagger-spec

Test Plan: Load it and hit authenticated endpoints to see them work;
check headers via chrome network inspector to notice the correct
authorization header